### PR TITLE
Change python version of make_data.sh

### DIFF
--- a/make_data.sh
+++ b/make_data.sh
@@ -4,6 +4,6 @@ source /opt/venv/dev/bin/activate
 cd data
 find . -name '.DS_Store' -type f -delete
 cd ../scripts
-python make_data.py client
-python make_data.py server
+python2 make_data.py client
+python2 make_data.py server
 cd ../


### PR DESCRIPTION
the script syntax seems to come from python 2 and can't be executed in python 3, also in make_data.bat it is executed in python 2.7:
```
C:\Python27\python make_data.py client
C:\Python27\python make_data.py server
```
