### PR TITLE
Add account ID of killer in DeathCameraMenu for Freeplay

### DIFF
--- a/client/src/com/desertkun/brainout/mode/ClientGameRealization.java
+++ b/client/src/com/desertkun/brainout/mode/ClientGameRealization.java
@@ -409,7 +409,11 @@ public abstract class ClientGameRealization<G extends GameMode> extends ClientRe
             public void run()
             {
                 ps.popAllUntil(ActionPhaseMenu.class);
-                ps.pushMenu(new DeathCameraMenu(map, killer, info, this::done));
+                ps.pushMenu(new DeathCameraMenu(map,
+                    killer,
+                    info,
+                    this::done,
+                    getGameMode().getID() == GameMode.ID.free));
             }
         });
     }


### PR DESCRIPTION
Added a small label text showing the account id of the killer only for freeplay. Useful for recorded reports.

Example:

https://user-images.githubusercontent.com/30794365/161921465-2fff105f-3687-4bef-a75b-33e0f3631ba2.mp4

Inspired by a suggestion from the official BRAIN/OUT Discord
![image](https://user-images.githubusercontent.com/30794365/161919963-07ef6692-eccd-4faa-8664-008a9e1d0482.png)
