### PR TITLE
Fix max-speed set to 1

### DIFF
--- a/core/src/com/desertkun/brainout/data/Map.java
+++ b/core/src/com/desertkun/brainout/data/Map.java
@@ -11,17 +11,19 @@ import com.desertkun.brainout.Constants;
 import com.desertkun.brainout.content.Content;
 import com.desertkun.brainout.content.active.Active;
 import com.desertkun.brainout.content.block.Block;
-import com.desertkun.brainout.content.block.Concrete;
 import com.desertkun.brainout.content.consumable.ConsumableItem;
 import com.desertkun.brainout.content.instrument.Instrument;
 import com.desertkun.brainout.data.active.ActiveData;
-import com.desertkun.brainout.data.components.ActiveFilterComponentData;
-import com.desertkun.brainout.events.ActiveActionEvent;
 import com.desertkun.brainout.data.block.BlockData;
 import com.desertkun.brainout.data.bullet.BulletData;
+import com.desertkun.brainout.data.components.ActiveFilterComponentData;
 import com.desertkun.brainout.data.containers.*;
 import com.desertkun.brainout.data.instrument.InstrumentData;
-import com.desertkun.brainout.data.interfaces.*;
+import com.desertkun.brainout.data.interfaces.ComponentWritable;
+import com.desertkun.brainout.data.interfaces.RenderContext;
+import com.desertkun.brainout.data.interfaces.RenderUpdatable;
+import com.desertkun.brainout.data.interfaces.Watcher;
+import com.desertkun.brainout.events.ActiveActionEvent;
 import com.desertkun.brainout.events.SetBlockEvent;
 import com.desertkun.brainout.events.UpdatedEvent;
 import com.desertkun.brainout.inspection.Inspectable;
@@ -867,7 +869,7 @@ public abstract class Map extends DataContainer<RenderUpdatable> implements Json
         json.writeValue("dimension", dimension);
         json.writeValue("dimensionId", dimensionId);
         json.writeValue("contentIndex", contentIndex);
-        json.writeValue("speed", speed);
+        json.writeValue("speed", Math.min(1.0F, speed));
         json.writeValue("name", name);
 
         json.writeObjectStart("custom");
@@ -1164,7 +1166,7 @@ public abstract class Map extends DataContainer<RenderUpdatable> implements Json
             contentIndex.read(json, jsonData.get("contentIndex"));
         }
 
-        speed = jsonData.getFloat("speed", speed);
+        speed = jsonData.getFloat("speed", Math.min(1.0F, speed));
         name = jsonData.getString("name", name);
 
         blocks.read(this, json, jsonData.get("blocks"));
@@ -1599,7 +1601,7 @@ public abstract class Map extends DataContainer<RenderUpdatable> implements Json
 
     public void setSpeed(float speed)
     {
-        this.speed = speed;
+        this.speed = Math.min(1.0F, speed);
     }
 
     public float getSpeed()

--- a/server/src/com/desertkun/brainout/server/ServerController.java
+++ b/server/src/com/desertkun/brainout/server/ServerController.java
@@ -11,13 +11,11 @@ import com.desertkun.brainout.client.ConnectionList;
 import com.desertkun.brainout.client.PlayerClient;
 import com.desertkun.brainout.common.msg.client.SimpleMsg;
 import com.desertkun.brainout.common.msg.server.*;
-import com.desertkun.brainout.components.PlayerOwnerComponent;
 import com.desertkun.brainout.components.PlayerRemoteComponent;
 import com.desertkun.brainout.content.Content;
 import com.desertkun.brainout.content.Levels;
 import com.desertkun.brainout.content.SpectatorTeam;
 import com.desertkun.brainout.content.Team;
-import com.desertkun.brainout.content.bullet.Bullet;
 import com.desertkun.brainout.content.upgrades.Upgrade;
 import com.desertkun.brainout.content.upgrades.UpgradeChain;
 import com.desertkun.brainout.data.Data;
@@ -31,10 +29,11 @@ import com.desertkun.brainout.data.components.ServerTeamVisibilityComponentData;
 import com.desertkun.brainout.data.components.base.Component;
 import com.desertkun.brainout.data.interfaces.Spawnable;
 import com.desertkun.brainout.events.*;
-import com.desertkun.brainout.events.Event;
 import com.desertkun.brainout.mode.GameMode;
 import com.desertkun.brainout.mode.ServerRealization;
-import com.desertkun.brainout.online.*;
+import com.desertkun.brainout.online.PlayerRights;
+import com.desertkun.brainout.online.Preset;
+import com.desertkun.brainout.online.RoomSettings;
 import com.desertkun.brainout.playstate.PlayState;
 import com.desertkun.brainout.playstate.ServerPSGame;
 import com.desertkun.brainout.plugins.Plugin;
@@ -49,7 +48,6 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.function.Consumer;
 
 public class ServerController extends Controller implements EventReceiver
 {
@@ -1591,6 +1589,8 @@ public class ServerController extends Controller implements EventReceiver
 
     public void setSpeed(float speed)
     {
+        // F hyper speed
+        speed = Math.min(1.0F, speed);
         for (ServerMap map : Map.All(ServerMap.class))
         {
             map.setSpeed(speed);


### PR DESCRIPTION
Avoid server/client speed receive a number higher than 1 (when the game never use it).

This should fix an internal modification of the client speed desync with server.
HOWEVER, it's just a temporary solution for a more complicated problem (server needs more client checking).