### PR TITLE
Fix Foxhunt's payload

### DIFF
--- a/server/src/com/desertkun/brainout/mode/ServerFoxHuntRealization.java
+++ b/server/src/com/desertkun/brainout/mode/ServerFoxHuntRealization.java
@@ -197,12 +197,10 @@ public class ServerFoxHuntRealization extends ServerRealization<GameModeFoxHunt>
     private void setPlayerAsFox(Client player)
     {
         PlayerData playerData = player.getPlayerData();
-
         if (playerData == null)
             return;
 
         ModePayload payload = player.getModePayload();
-
         if (!(payload instanceof FoxHuntPayload))
             return;
 
@@ -394,11 +392,7 @@ public class ServerFoxHuntRealization extends ServerRealization<GameModeFoxHunt>
         {
             Client client1 = entry.value;
 
-            if (client1 == fox)
-                continue;
-
-            if (!client1.isAlive())
-                continue;
+            if (client1 == fox || !client1.isAlive()) continue;
 
             clientList.add(client1);
         }

--- a/server/src/com/desertkun/brainout/playstate/ServerPSGame.java
+++ b/server/src/com/desertkun/brainout/playstate/ServerPSGame.java
@@ -192,25 +192,26 @@ public class ServerPSGame extends PlayStateGame
         C.getClients().clearHistory();
         C.getClients().updateBalance(true);
 
-        for (ObjectMap.Entry<Integer, Client> entry : C.getClients())
-        {
-            Client client = entry.value;
+        BrainOut.Timer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                for (ObjectMap.Entry<Integer, Client> entry : C.getClients())
+                {
+                    Client client = entry.value;
 
-            if (client instanceof PlayerClient)
-            {
-                PlayerClient playerClient = ((PlayerClient) client);
-                // Wait 1 second to let player's state to change
-                BrainOut.Timer.schedule(new TimerTask() {
-                    @Override
-                    public void run() {
+                    if (client instanceof PlayerClient)
+                    {
+                        PlayerClient playerClient = ((PlayerClient) client);
+                        // Wait 1 second to let player's state to change
                         if (!playerClient.isInitialized()) return;
 
                         playerClient.setModePayload(
                             ((ServerRealization) getMode().getRealization()).newPlayerPayload(playerClient));
                     }
-                }, TimeUnit.SECONDS.toMillis(1));
+                }
             }
-        }
+        }, TimeUnit.SECONDS.toMillis(1));
+
 
         if (BrainOut.OnlineEnabled())
         {
@@ -252,7 +253,7 @@ public class ServerPSGame extends PlayStateGame
         {
             if (team == null)
                 continue;
-            
+
             json.writeValue(team.getID());
         }
         json.writeArrayEnd();

--- a/server/src/com/desertkun/brainout/playstate/ServerPSGame.java
+++ b/server/src/com/desertkun/brainout/playstate/ServerPSGame.java
@@ -6,7 +6,6 @@ import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.ObjectSet;
 import com.desertkun.brainout.BrainOut;
 import com.desertkun.brainout.BrainOutServer;
-import com.desertkun.brainout.Constants;
 import com.desertkun.brainout.client.Client;
 import com.desertkun.brainout.client.PlayerClient;
 import com.desertkun.brainout.common.msg.ModeMessage;
@@ -31,6 +30,9 @@ import org.anthillplatform.runtime.requests.Request;
 import org.anthillplatform.runtime.services.EventService;
 import org.anthillplatform.runtime.services.LoginService;
 import org.json.JSONArray;
+
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
 
 public class ServerPSGame extends PlayStateGame
 {
@@ -197,12 +199,16 @@ public class ServerPSGame extends PlayStateGame
             if (client instanceof PlayerClient)
             {
                 PlayerClient playerClient = ((PlayerClient) client);
+                // Wait 1 second to let player's state to change
+                BrainOut.Timer.schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        if (!playerClient.isInitialized()) return;
 
-                if (playerClient.isInitialized())
-                {
-                    playerClient.setModePayload(
-                        ((ServerRealization) getMode().getRealization()).newPlayerPayload(playerClient));
-                }
+                        playerClient.setModePayload(
+                            ((ServerRealization) getMode().getRealization()).newPlayerPayload(playerClient));
+                    }
+                }, TimeUnit.SECONDS.toMillis(1));
             }
         }
 


### PR DESCRIPTION
Delay player's init state to wait a new state and set gamemode's payload.
- If this process takes more longer, this could not work as intended.
- In that case, a StateChangeEvent should be created to add a payload automatically.